### PR TITLE
Including <linux/bug.h>

### DIFF
--- a/imanager-ec-bl.c
+++ b/imanager-ec-bl.c
@@ -12,6 +12,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>

--- a/imanager-ec-gpio.c
+++ b/imanager-ec-gpio.c
@@ -12,6 +12,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>

--- a/imanager-ec-hwmon.c
+++ b/imanager-ec-hwmon.c
@@ -12,6 +12,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>

--- a/imanager-ec-i2c.c
+++ b/imanager-ec-i2c.c
@@ -12,6 +12,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>

--- a/imanager-ec-wdt.c
+++ b/imanager-ec-wdt.c
@@ -15,6 +15,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>

--- a/imanager-ec.c
+++ b/imanager-ec.c
@@ -12,6 +12,7 @@
 
 #include <linux/types.h>
 #include <linux/errno.h>
+#include <linux/bug.h>
 #include <linux/io.h>
 #include <linux/delay.h>
 #include <linux/string.h>


### PR DESCRIPTION
The WARN_ON macro is defined in asm-generic/bug.h.  Previous versions of
linux included this file in the dependencies of errno.h.  With 4.2.5, we
must explicitly include the bug.h file to get the macro definitions.
