### PR TITLE
Fixed i2c_smbus_write_byte() NULL pointer error.

### DIFF
--- a/i2c-imanager.c
+++ b/i2c-imanager.c
@@ -270,16 +270,18 @@ static s32 imanager_i2c_xfer(struct i2c_adapter *adap, u16 addr, ushort flags,
 			msg.u.smb.hdr.wlen = 1;
 			msg.u.smb.hdr.cmd = command;
 			val = imanager_i2c_wr_combined(io, &msg);
+			if (val < 0)
+				ret = val;
 		} else {
 			msg.rlen = 1;
 			msg.u.smb.hdr.rlen = 1;
 			msg.u.smb.hdr.wlen = 0;
 			val = imanager_i2c_rw_combined(io, &msg);
+			if (val < 0)
+				ret = val;
+			else
+				smb_data->byte = val;
 		}
-		if (val < 0)
-			ret = val;
-		else
-			smb_data->byte = val;
 		break;
 	case I2C_SMBUS_BYTE_DATA:
 		if (read_write == I2C_SMBUS_WRITE) {


### PR DESCRIPTION
The function imanager_i2c_xfer() is called with smb_data as NULL when running
i2c_smbus_write_byte() (see include/linux/i2c-dev.h).  This commit fixes a
runtime error if trying to assign to smb_data->byte when smb_data is NULL.
